### PR TITLE
Need index.js for addon to run

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./lib/dependency-checker');

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "doc": "doc",
     "test": "tests"
   },
-  "main": "lib/dependency-checker",
   "scripts": {
     "start": "ember server",
     "build": "ember build",


### PR DESCRIPTION
This is a fix to #7. The addon won't run unless there is a `index.js` at the root level, despite the main script specified in `package.json`.
