### PR TITLE
Fix  detection of bower dependencies installed from http(s)

### DIFF
--- a/lib/dependency-checker.js
+++ b/lib/dependency-checker.js
@@ -52,6 +52,11 @@ EmberCLIDependencyChecker.prototype.lookupBowerPackageVersion = function(name) {
   if (!version) {
     var bowerFile = path.join(this.project.root, this.project.bowerDirectory, name, 'bower.json');
     version = this.lookupPackageVersion(bowerFile);
+    if (version === null) {
+        if (fileExists(path.join(this.project.root, this.project.bowerDirectory, name))) {
+            version = undefined;
+        }
+    }
   }
   return version;
 };
@@ -77,12 +82,15 @@ EmberCLIDependencyChecker.prototype.readBowerDependencies = function() {
   return Object.keys(dependencies).map(function(name) {
     var versionSpecified = dependencies[name];
     var versionInstalled = this.lookupBowerPackageVersion(name);
-    
+
     if (versionSpecified.substr(0, 7) === 'http://' || versionSpecified.substr(0, 8) === 'https://') {
       versionInstalled = '*';
     }
 
-    
+    if (versionSpecified === '*' && versionInstalled === undefined) {
+      versionInstalled = '0.0.0';
+    }
+
     return new Package(name, versionSpecified, versionInstalled);
   }, this);
 };


### PR DESCRIPTION
this.lookupBowerPackageVersion(name) returns null if a dependency is installed from http(s) and so the version check fails.
