### PR TITLE
Add an ENV variable to allow opting out.

### DIFF
--- a/lib/dependency-checker.js
+++ b/lib/dependency-checker.js
@@ -21,7 +21,7 @@ function EmberCLIDependencyChecker(project) {
 
 EmberCLIDependencyChecker.prototype.checkDependencies = function() {
 
-  if(alreadyChecked) {
+  if(alreadyChecked || process.env.SKIP_DEPENDENCY_CHECKER) {
     return;
   }
 


### PR DESCRIPTION
When testing a new version of a dependency, I often resort to removing the dependency checker from the `package.json` temporarily.

This PR allows opting out via an explicit environment variable to make testing updated dependencies easier.

```
SKIP_DEPENDENCY_CHECKER=true ember s
```