### PR TITLE
Use init instead of a bare constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,12 +3,11 @@
 var Reporter = require('./lib/reporter');
 var DependencyChecker = require('./lib/dependency-checker');
 
-module.exports = function emberCliDependencyCheckerAddon(project) {
-  var reporter = new Reporter();
-  var dependencyChecker = new DependencyChecker(project, reporter);
-  dependencyChecker.checkDependencies();
-
-  return {
-    name: 'ember-cli-dependency-checker'
-  };
+module.exports = {
+  name: 'ember-cli-dependency-checker',
+  init: function() {
+    var reporter = new Reporter();
+    var dependencyChecker = new DependencyChecker(this.project, reporter);
+    dependencyChecker.checkDependencies();
+  }
 };


### PR DESCRIPTION
Ember-CLI 0.2.4 expects some properties to be on addon objects, and dislike the bare constructor we used before.

This addresses a bug ember-cli-dependency-checker causes with `ember install` on Ember-CLI 0.2.4.