### PR TITLE
remove ember-cli-babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   "dependencies": {
     "chalk": "^0.5.1",
     "is-git-url": "^0.2.0",
-    "semver": "^4.1.0",
-    "ember-cli-babel": "^5.0.0"
+    "semver": "^4.1.0"
   }
 }


### PR DESCRIPTION
I don't believe this add-on actually needs  ember-cli-babel, as it is purely written in ES5 node code.