### PR TITLE
Circumvent dependency checker when testing blueprints

### DIFF
--- a/lib/dependency-checker.js
+++ b/lib/dependency-checker.js
@@ -24,13 +24,17 @@ function isNotSymlinked(pkg) {
   return !pkg.isSymlinked;
 }
 
+function isDisabled(project) {
+  return project && project.cli && project.cli.disableDependencyChecker;
+}
+
 function EmberCLIDependencyChecker(project, reporter) {
   this.project = project;
   this.reporter = reporter;
 }
 
 EmberCLIDependencyChecker.prototype.checkDependencies = function() {
-  if (alreadyChecked || process.env.SKIP_DEPENDENCY_CHECKER) {
+  if (alreadyChecked || process.env.SKIP_DEPENDENCY_CHECKER || isDisabled(this.project)) {
     return;
   }
 


### PR DESCRIPTION
When testing blueprints, there is a need to circumvent the dependency checker since we're not actually installing npm and bower dependencies, we're just testing that the blueprint installs the correct files with the correct contents.

This PR adds a check for `project.cli.testing` which is set when the ember test helper is [used here](https://github.com/ember-cli/ember-cli/blob/master/tests/helpers/ember.js#L18). We should not be running the dependency checker when testing, as we skip npm and bower installs while testing.