### PR TITLE
Detect npm >=3.9.2 and adjust the install command accordingly

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,14 +1,30 @@
 'use strict';
+var versionChecker = require('./version-checker');
 
 function installCommand(type) {
   switch (type) {
   case 'npm':
     return 'npm install';
   case 'npm-shrinkwrap':
+    // npm v3.9.1 included a fix for the bug which makes the rm -rf node_modules
+    // necessary ( https://github.com/npm/npm/issues/12372 ), but also exposed
+    // a different bug which was fixed in npm v3.9.2
+    // ( https://github.com/npm/npm/pull/12724 )
+    if (versionChecker.satisfies('>=3.9.2', getNpmVersion())) {
+      return 'npm install';
+    }
     return 'rm -rf node_modules/ && npm install';
   case 'bower':
     return 'bower install';
   }
+}
+
+function getNpmVersion() {
+  try {
+    return require('child_process').execSync('npm -v').toString();
+  } catch (e) {
+  }
+  return undefined;
 }
 
 var Reporter = function() {


### PR DESCRIPTION
With later versions of npm, it's no longer necessary to `rm -rf node_modules` before `npm install` when sub-dependency versions are not correct.

npm v3.9.1 fixed the [issue](https://github.com/npm/npm/issues/12372), but also exposed a different bug which was [fixed](https://github.com/npm/npm/pull/12724) in npm v3.9.2
