### PR TITLE
Suggest `bower update` instead of `bower install`

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -7,7 +7,7 @@ function installCommand(type) {
   case 'npm-shrinkwrap':
     return 'rm -rf node_modules/ && npm install';
   case 'bower':
-    return 'bower install';
+    return 'bower update';
   }
 }
 


### PR DESCRIPTION
`bower install` is a confusing suggestion for outdated dependencies, due to Bower's frequent failure to upgrade versions w/ `install` if the package is not altogether missing.
