### PR TITLE
Update is-git-url semvar

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   ],
   "dependencies": {
     "chalk": "^0.5.1",
-    "is-git-url": "0.2.0",
+    "is-git-url": "^0.2.0",
     "semver": "^4.1.0"
   },
   "ember-addon": {


### PR DESCRIPTION
Any reason it's pinned at "0.2.0"?