### PR TITLE
Better error messaging for version errors

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -12,8 +12,15 @@ Package.prototype.init = function(name, versionSpecified, versionInstalled, path
   this.path = path;
   this.versionSpecified = versionSpecified;
   this.versionInstalled = versionInstalled;
-  this.needsUpdate = this.updateRequired();
-  this.isSymlinked = this.symlinked();
+  
+  try {
+    this.needsUpdate = this.updateRequired();
+    this.isSymlinked = this.symlinked();
+  } catch(e) {
+    var versionText = '(version specified: ' + versionSpecified + ', version installed: ' + versionInstalled + '): ';
+    e.message = 'Failed processing module "' + name + '" ' + versionText + e.message;
+    throw e;
+  }
 };
 
 Package.prototype.updateRequired = function() {


### PR DESCRIPTION
This includes the name and versions of the module alongside the message.

Before:
<img width="802" alt="screen shot 2017-11-10 at 10 07 47 am" src="https://user-images.githubusercontent.com/34726/32664371-0796a23e-c5ff-11e7-9787-ea83a5008a7c.png">

Now:
<img width="866" alt="screen shot 2017-11-10 at 10 08 17 am" src="https://user-images.githubusercontent.com/34726/32664403-1e04e580-c5ff-11e7-9e1a-0051fa091205.png">

