### PR TITLE
Check tar.gz urls if they are specified in _from in package.json

### DIFF
--- a/lib/dependency-checker.js
+++ b/lib/dependency-checker.js
@@ -9,6 +9,8 @@ var readDir    = fs.readdirSync;
 var fileExists = fs.existsSync;
 var Package    = require('./package');
 var buildBowerPackagePath = require('./utils/build-bower-package-path');
+var isTarGz    = require('./utils/is-tar-gz');
+var unknownVersion = require('./utils/unknown-version');
 
 var alreadyChecked = false;
 
@@ -84,10 +86,10 @@ EmberCLIDependencyChecker.prototype.readShrinkwrapDeps = function() {
   }
 };
 
-EmberCLIDependencyChecker.prototype.lookupNodeModule = function(name) {
+EmberCLIDependencyChecker.prototype.lookupNodeModule = function(name, versionSpecified) {
   try {
     var nodePackage = resolve.sync(path.join(name, 'package.json'), { basedir: this.project.root });
-    var version = this.lookupPackageVersion(nodePackage);
+    var version = this.lookupPackageVersion(nodePackage, versionSpecified);
     return { version: version, path: path.dirname(nodePackage) };
   } catch(err) {
     return { version: null, path: null };
@@ -108,12 +110,16 @@ EmberCLIDependencyChecker.prototype.lookupBowerPackageVersion = function(name) {
   return version;
 };
 
-EmberCLIDependencyChecker.prototype.lookupPackageVersion = function(path) {
+EmberCLIDependencyChecker.prototype.lookupPackageVersion = function(path, versionSpecified) {
   if (fileExists(path)) {
     var pkg = readFile(path);
     var version = null;
     try {
-      version = JSON.parse(pkg).version || null;
+      var pkgContent = JSON.parse(pkg);
+      version = pkgContent.version || null;
+      if (isTarGz(versionSpecified)) {
+        version = pkgContent._from || unknownVersion;
+      }
     } catch(e) {
       // JSON parse error
     }
@@ -135,10 +141,13 @@ EmberCLIDependencyChecker.prototype.readDependencies = function(dependencies, ty
   return Object.keys(dependencies).map(function(name) {
     var versionSpecified = dependencies[name];
     if (type === 'npm') {
-      var result = this.lookupNodeModule(name);
+      var result = this.lookupNodeModule(name, versionSpecified);
       return new Package(name, versionSpecified, result.version, result.path);
     } else {
       var versionInstalled = this.lookupBowerPackageVersion(name);
+      if (isTarGz(versionSpecified)) {
+        versionInstalled = unknownVersion;
+      }
       var path = buildBowerPackagePath(this.project, name);
       return new Package(name, versionSpecified, versionInstalled, path);
     }

--- a/lib/utils/is-tar-gz.js
+++ b/lib/utils/is-tar-gz.js
@@ -1,0 +1,5 @@
+const regex = /((\.tar(\.gz)?)|(\.tgz))$/;
+
+module.exports = function isTarGz(str) {
+  return regex.test(str);
+};

--- a/lib/utils/unknown-version.js
+++ b/lib/utils/unknown-version.js
@@ -1,0 +1,1 @@
+module.exports = '__UNKNOWN_VERSION__';

--- a/lib/version-checker.js
+++ b/lib/version-checker.js
@@ -11,6 +11,8 @@ VersionChecker.satisfies = function(versionSpecified, versionInstalled) {
   var version   = versionSpecified;
   var isGitRepo = require('is-git-url');
   var semver    = require('semver');
+  var isTarGz   = require('./utils/is-tar-gz');
+  var unknownVersion = require('./utils/unknown-version');
 
   if (version === '*') {
     return true;
@@ -22,6 +24,8 @@ VersionChecker.satisfies = function(versionSpecified, versionInstalled) {
         return true;
       }
     }
+  } else if (isTarGz(version) && versionInstalled !== unknownVersion) {
+    return version === versionInstalled;
   }
 
   if (!semver.validRange(version)) {

--- a/tests/fixtures/project-npm-tar-gz-check/node_modules/example-tar-gz/package.json
+++ b/tests/fixtures/project-npm-tar-gz-check/node_modules/example-tar-gz/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "example-tar-gz",
+  "version": "2.0.0",
+  "_from": "http://ember-cli.com/example-2.0.0.tar.gz"
+}

--- a/tests/fixtures/project-yarn-tar-gz-check/node_modules/example-tar-gz/package.json
+++ b/tests/fixtures/project-yarn-tar-gz-check/node_modules/example-tar-gz/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "example-tar-gz",
+  "version": "2.0.0",
+  "_from": "http://ember-cli.com/example-2.0.0.tar.gz"
+}

--- a/tests/unit/dependency-checker-package-manager-test.js
+++ b/tests/unit/dependency-checker-package-manager-test.js
@@ -54,6 +54,16 @@ describe('EmberCLIDependencyChecker', function() {
         var project = createProject({ 'ember-cli': 'git://github.com/stefanpenner/ember-cli.git#v0.1.0' });
         assertPackageManagerError(project);
       });
+
+      it('when the version specified is a url to a tar.gz  and a _from is provided in the package.json and does not match', function() {
+        var project = createProject({ 'example-tar-gz': 'http://ember-cli.com/example-3.0.0.tar.gz' }, { root: 'tests/fixtures/project-'+ packageManagerName + '-tar-gz-check' });
+        assertPackageManagerError(project);
+      });
+
+      it('when the version specified is a url to a tar.gz  and no package is installed', function() {
+        var project = createProject({ 'example-2-tar-gz': 'http://ember-cli.com/example-2-2.0.0.tar.gz' }, { root: 'tests/fixtures/project-'+ packageManagerName + '-tar-gz-check' });
+        assertPackageManagerError(project);
+      });
     });
 
     describe('does not report satisfied ' + packageManagerName + ' dependencies', function() {
@@ -94,6 +104,11 @@ describe('EmberCLIDependencyChecker', function() {
 
       it('when the version specified is found outside the project root', function() {
         var project = createProject({ 'example-package': '1.2.3' }, { root: 'tests/fixtures/outside-root-' + packageManagerName + '-project/project' });
+        assertNoPackageManagerError(project);
+      });
+
+      it('when the version specified is a url to a tar.gz  and a _from is provided in the package.json and urls match', function() {
+        var project = createProject({ 'example-tar-gz': 'http://ember-cli.com/example-2.0.0.tar.gz' }, { root: 'tests/fixtures/project-'+ packageManagerName + '-tar-gz-check' });
         assertNoPackageManagerError(project);
       });
     });

--- a/tests/unit/is-tar-gz-test.js
+++ b/tests/unit/is-tar-gz-test.js
@@ -1,0 +1,45 @@
+var assert = require('chai').assert;
+var isTarGz = require('../../lib/utils/is-tar-gz');
+
+describe('IsTarGz', function () {
+  describe('recognizes tar ball', function () {
+
+    it('when url ends with .tar', function () {
+      var url = 'http://ember-cli.com/example-2.0.0.tar';
+      assert.ok(isTarGz(url));
+    });
+
+    it('when url ends with .tar.gz', function () {
+      var url = 'http://ember-cli.com/example-2.0.0.tar.gz';
+      assert.ok(isTarGz(url));
+    });
+
+    it('when url ends with .tgz', function () {
+      var url = 'http://ember-cli.com/example-2.0.0.tgz';
+      assert.ok(isTarGz(url));
+    });
+  });
+
+  describe('recognizes that url is not a tar ball', function () {
+    it('when url contains .tar somewhere', function () {
+      var url = 'http://ember-cli.com/example-2.0.0.tar.zip';
+      assert.notOk(isTarGz(url));
+    });
+
+    it('when url contains .tar.gz somewhere', function () {
+      var url = 'http://ember-cli.com/example-2.0.0.tar.gz.zip';
+      assert.notOk(isTarGz(url));
+    });
+
+    it('when url contains .tgz somewhere', function () {
+      var url = 'http://ember-cli.com/example-2.0.0.tgz.zip';
+      assert.notOk(isTarGz(url));
+    });
+
+    it('when url contains no .tar, .tar.gz or .tgz', function () {
+      var url = 'http://ember-cli.com/example-2.0.0.zip';
+      assert.notOk(isTarGz(url));
+    });
+  });
+
+});


### PR DESCRIPTION
We are using `tar.gz` urls to manage some of our dependencies. This is due to the fact that these dependencies are very big binary blobs and we don't want to add these big blobs to a git repository. But `tar.gz` urls are not version checked in `ember-cli-dependency-checker` which often leads to confusion in our development team. Therefore I propose to check the `_from` property in the `package.json` if present, if not the old behavior should be applied.