### PR TITLE
Use ES6 classes

### DIFF
--- a/lib/dependency-checker.js
+++ b/lib/dependency-checker.js
@@ -30,132 +30,134 @@ function isDisabled(project) {
   return project && project.cli && project.cli.disableDependencyChecker;
 }
 
-function EmberCLIDependencyChecker(project, reporter) {
-  this.project = project;
-  this.reporter = reporter;
-}
-
-EmberCLIDependencyChecker.prototype.checkDependencies = function() {
-  if (alreadyChecked || process.env.SKIP_DEPENDENCY_CHECKER || isDisabled(this.project)) {
-    return;
+class EmberCLIDependencyChecker {
+  constructor(project, reporter) {
+    this.project = project;
+    this.reporter = reporter;
   }
 
-  const bowerDeps = this.readBowerDependencies();
-  this.reporter.unsatisifedPackages('bower', bowerDeps.filter(isUnsatisfied));
-
-  const npmDeps = this.readNPMDependencies();
-  const filteredDeps = npmDeps.filter(isUnsatisfied);
-  const unsatisfiedDeps = filteredDeps.filter(isNotSymlinked);
-  const symlinkedDeps = filteredDeps.filter(isSymlinked);
-
-  const yarnPath = path.join(this.project.root, 'yarn.lock');
-  const yarnWorkspacePath = findYarnWorkspaceRoot(this.project.root);
-
-  let packageManagerName = 'npm';
-  if (fileExists(yarnPath) || yarnWorkspacePath) {
-    packageManagerName = 'yarn';
-  }
-
-  this.reporter.reportUnsatisfiedSymlinkedPackages(packageManagerName, symlinkedDeps);
-  this.reporter.unsatisifedPackages(packageManagerName, unsatisfiedDeps);
-
-  if (unsatisfiedDeps.length === 0) {
-    const shrinkWrapDeps = this.readShrinkwrapDeps();
-    this.reporter.unsatisifedPackages('npm-shrinkwrap', shrinkWrapDeps.filter(isUnsatisfied));
-  }
-
-  EmberCLIDependencyChecker.setAlreadyChecked(true);
-
-  this.reporter.report();
-};
-
-EmberCLIDependencyChecker.prototype.readShrinkwrapDeps = function() {
-  const filePath = path.join(this.project.root, 'npm-shrinkwrap.json');
-  if (fileExists(filePath)) {
-    const ShrinkWrapChecker = require('./shrinkwrap-checker');
-    const shrinkWrapBody = readFile(filePath);
-    let shrinkWrapJSON = {};
-    try {
-      shrinkWrapJSON = JSON.parse(shrinkWrapBody);
-    } catch(e) {
-      // JSON parse error
+  checkDependencies() {
+    if (alreadyChecked || process.env.SKIP_DEPENDENCY_CHECKER || isDisabled(this.project)) {
+      return;
     }
-    return ShrinkWrapChecker.checkDependencies(this.project.root, shrinkWrapJSON);
-  } else {
-    return [];
-  }
-};
 
-EmberCLIDependencyChecker.prototype.lookupNodeModule = function(name, versionSpecified) {
-  try {
-    const nodePackage = resolve.sync(path.join(name, 'package.json'), { basedir: this.project.root });
-    const version = this.lookupPackageVersion(nodePackage, versionSpecified);
-    return { version: version, path: path.dirname(nodePackage) };
-  } catch(err) {
-    return { version: null, path: null };
-  }
-};
+    const bowerDeps = this.readBowerDependencies();
+    this.reporter.unsatisifedPackages('bower', bowerDeps.filter(isUnsatisfied));
 
-EmberCLIDependencyChecker.prototype.lookupBowerPackageVersion = function(name) {
-  const packageDirectory = path.resolve(this.project.root, this.project.bowerDirectory, name);
-  let version = null;
-  if (fileExists(packageDirectory) && readDir(packageDirectory).length > 0) {
-    const dotBowerFile = path.join(packageDirectory, '.bower.json');
-    version = this.lookupPackageVersion(dotBowerFile);
-    if (!version) {
-      const bowerFile = path.join(packageDirectory, 'bower.json');
-      version = this.lookupPackageVersion(bowerFile) || '*';
+    const npmDeps = this.readNPMDependencies();
+    const filteredDeps = npmDeps.filter(isUnsatisfied);
+    const unsatisfiedDeps = filteredDeps.filter(isNotSymlinked);
+    const symlinkedDeps = filteredDeps.filter(isSymlinked);
+
+    const yarnPath = path.join(this.project.root, 'yarn.lock');
+    const yarnWorkspacePath = findYarnWorkspaceRoot(this.project.root);
+
+    let packageManagerName = 'npm';
+    if (fileExists(yarnPath) || yarnWorkspacePath) {
+      packageManagerName = 'yarn';
     }
-  }
-  return version;
-};
 
-EmberCLIDependencyChecker.prototype.lookupPackageVersion = function(path, versionSpecified) {
-  if (fileExists(path)) {
-    const pkg = readFile(path);
-    let version = null;
-    try {
-      const pkgContent = JSON.parse(pkg);
-      version = pkgContent.version || null;
-      if (isTarGz(versionSpecified)) {
-        version = pkgContent._from || unknownVersion;
+    this.reporter.reportUnsatisfiedSymlinkedPackages(packageManagerName, symlinkedDeps);
+    this.reporter.unsatisifedPackages(packageManagerName, unsatisfiedDeps);
+
+    if (unsatisfiedDeps.length === 0) {
+      const shrinkWrapDeps = this.readShrinkwrapDeps();
+      this.reporter.unsatisifedPackages('npm-shrinkwrap', shrinkWrapDeps.filter(isUnsatisfied));
+    }
+
+    EmberCLIDependencyChecker.setAlreadyChecked(true);
+
+    this.reporter.report();
+  }
+
+  readShrinkwrapDeps() {
+    const filePath = path.join(this.project.root, 'npm-shrinkwrap.json');
+    if (fileExists(filePath)) {
+      const ShrinkWrapChecker = require('./shrinkwrap-checker');
+      const shrinkWrapBody = readFile(filePath);
+      let shrinkWrapJSON = {};
+      try {
+        shrinkWrapJSON = JSON.parse(shrinkWrapBody);
+      } catch(e) {
+        // JSON parse error
       }
-    } catch(e) {
-      // JSON parse error
+      return ShrinkWrapChecker.checkDependencies(this.project.root, shrinkWrapJSON);
+    } else {
+      return [];
+    }
+  }
+
+  lookupNodeModule(name, versionSpecified) {
+    try {
+      const nodePackage = resolve.sync(path.join(name, 'package.json'), { basedir: this.project.root });
+      const version = this.lookupPackageVersion(nodePackage, versionSpecified);
+      return { version: version, path: path.dirname(nodePackage) };
+    } catch(err) {
+      return { version: null, path: null };
+    }
+  }
+
+  lookupBowerPackageVersion(name) {
+    const packageDirectory = path.resolve(this.project.root, this.project.bowerDirectory, name);
+    let version = null;
+    if (fileExists(packageDirectory) && readDir(packageDirectory).length > 0) {
+      const dotBowerFile = path.join(packageDirectory, '.bower.json');
+      version = this.lookupPackageVersion(dotBowerFile);
+      if (!version) {
+        const bowerFile = path.join(packageDirectory, 'bower.json');
+        version = this.lookupPackageVersion(bowerFile) || '*';
+      }
     }
     return version;
-  } else {
-    return null;
   }
-};
 
-EmberCLIDependencyChecker.prototype.readBowerDependencies = function() {
-  return this.readDependencies(this.project.bowerDependencies(), 'bower');
-};
-
-EmberCLIDependencyChecker.prototype.readNPMDependencies = function() {
-  return this.readDependencies(this.project.dependencies(), 'npm');
-};
-
-EmberCLIDependencyChecker.prototype.readDependencies = function(dependencies, type) {
-  return Object.keys(dependencies).map(function(name) {
-    const versionSpecified = dependencies[name];
-    if (type === 'npm') {
-      const result = this.lookupNodeModule(name, versionSpecified);
-      return new Package(name, versionSpecified, result.version, result.path);
-    } else {
-      let versionInstalled = this.lookupBowerPackageVersion(name);
-      if (isTarGz(versionSpecified)) {
-        versionInstalled = unknownVersion;
+  lookupPackageVersion(path, versionSpecified) {
+    if (fileExists(path)) {
+      const pkg = readFile(path);
+      let version = null;
+      try {
+        const pkgContent = JSON.parse(pkg);
+        version = pkgContent.version || null;
+        if (isTarGz(versionSpecified)) {
+          version = pkgContent._from || unknownVersion;
+        }
+      } catch(e) {
+        // JSON parse error
       }
-      const path = buildBowerPackagePath(this.project, name);
-      return new Package(name, versionSpecified, versionInstalled, path);
+      return version;
+    } else {
+      return null;
     }
-  }, this);
-};
+  }
 
-EmberCLIDependencyChecker.setAlreadyChecked = function(value) {
-  alreadyChecked = value;
-};
+  readBowerDependencies() {
+    return this.readDependencies(this.project.bowerDependencies(), 'bower');
+  }
+
+  readNPMDependencies() {
+    return this.readDependencies(this.project.dependencies(), 'npm');
+  }
+
+  readDependencies(dependencies, type) {
+    return Object.keys(dependencies).map(function(name) {
+      const versionSpecified = dependencies[name];
+      if (type === 'npm') {
+        const result = this.lookupNodeModule(name, versionSpecified);
+        return new Package(name, versionSpecified, result.version, result.path);
+      } else {
+        let versionInstalled = this.lookupBowerPackageVersion(name);
+        if (isTarGz(versionSpecified)) {
+          versionInstalled = unknownVersion;
+        }
+        const path = buildBowerPackagePath(this.project, name);
+        return new Package(name, versionSpecified, versionInstalled, path);
+      }
+    }, this);
+  }
+
+  static setAlreadyChecked(value) {
+    alreadyChecked = value;
+  }
+}
 
 module.exports = EmberCLIDependencyChecker;

--- a/lib/package.js
+++ b/lib/package.js
@@ -1,36 +1,35 @@
 'use strict';
 
-function Package() {
-  this.init.apply(this, arguments);
-}
-
-Package.prototype = Object.create({});
-Package.prototype.constructor = Package;
-
-Package.prototype.init = function(name, versionSpecified, versionInstalled, path) {
-  this.name = name;
-  this.path = path;
-  this.versionSpecified = versionSpecified;
-  this.versionInstalled = versionInstalled;
-
-  try {
-    this.needsUpdate = this.updateRequired();
-    this.isSymlinked = this.symlinked();
-  } catch(e) {
-    const versionText = '(version specified: ' + versionSpecified + ', version installed: ' + versionInstalled + '): ';
-    e.message = 'Failed processing module "' + name + '" ' + versionText + e.message;
-    throw e;
+class Package {
+  constructor() {
+    this.init.apply(this, arguments);
   }
-};
 
-Package.prototype.updateRequired = function() {
-  const VersionChecker = require('./version-checker');
-  return !VersionChecker.satisfies(this.versionSpecified, this.versionInstalled);
-};
+  init(name, versionSpecified, versionInstalled, path) {
+    this.name = name;
+    this.path = path;
+    this.versionSpecified = versionSpecified;
+    this.versionInstalled = versionInstalled;
 
-Package.prototype.symlinked = function() {
-  const isSymlink = require('./utils/is-symlink');
-  return isSymlink(this.path);
-};
+    try {
+      this.needsUpdate = this.updateRequired();
+      this.isSymlinked = this.symlinked();
+    } catch(e) {
+      const versionText = '(version specified: ' + versionSpecified + ', version installed: ' + versionInstalled + '): ';
+      e.message = 'Failed processing module "' + name + '" ' + versionText + e.message;
+      throw e;
+    }
+  }
+
+  updateRequired() {
+    const VersionChecker = require('./version-checker');
+    return !VersionChecker.satisfies(this.versionSpecified, this.versionInstalled);
+  }
+
+  symlinked() {
+    const isSymlink = require('./utils/is-symlink');
+    return isSymlink(this.path);
+  }
+}
 
 module.exports = Package;

--- a/lib/package.js
+++ b/lib/package.js
@@ -1,11 +1,7 @@
 'use strict';
 
 class Package {
-  constructor() {
-    this.init.apply(this, arguments);
-  }
-
-  init(name, versionSpecified, versionInstalled, path) {
+  constructor(name, versionSpecified, versionInstalled, path) {
     this.name = name;
     this.path = path;
     this.versionSpecified = versionSpecified;

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -13,59 +13,61 @@ function installCommand(type) {
   }
 }
 
-const Reporter = function() {
-  this.messages = [];
-};
-
-Reporter.prototype.unsatisifedPackages = function(type, packages) {
-  this.chalk = this.chalk || require('chalk');
-  this.EOL   = this.EOL || require('os').EOL;
-
-  const chalk = this.chalk;
-  const EOL   = this.EOL;
-
-  if (packages.length > 0) {
-    let message = '';
-    message += EOL + chalk.red('Missing ' + type + ' packages: ') + EOL;
-
-    packages.forEach(function(pkg) {
-      message += chalk.reset('Package: ') + chalk.cyan(pkg.name) + EOL;
-      if (pkg.parents) {
-        message += chalk.reset('Required by: ') + chalk.cyan(pkg.parents.join(' / ')) + EOL;
-      }
-      message += chalk.grey('  * Specified: ') + chalk.reset(pkg.versionSpecified) + EOL;
-      message += chalk.grey('  * Installed: ') + chalk.reset(pkg.versionInstalled || '(not installed)') + EOL + EOL;
-    });
-
-    message += chalk.red('Run `'+ installCommand(type) +'` to install missing dependencies.') + EOL;
-    this.messages.push(message);
+class Reporter {
+  constructor() {
+    this.messages = [];
   }
-};
 
-Reporter.prototype.reportUnsatisfiedSymlinkedPackages = function(type, packages) {
-  this.chalk = this.chalk || require('chalk');
-  this.EOL   = this.EOL || require('os').EOL;
+  unsatisifedPackages(type, packages) {
+    this.chalk = this.chalk || require('chalk');
+    this.EOL   = this.EOL || require('os').EOL;
 
-  const chalk = this.chalk;
-  const EOL   = this.EOL;
+    const chalk = this.chalk;
+    const EOL   = this.EOL;
 
-  if (packages.length > 0) {
-    let message = '';
-    message += EOL + chalk.yellow('Missing symlinked ' + type + ' packages: ') + EOL;
-    packages.forEach(function(pkg) {
-      message += chalk.reset('Package: ') + chalk.cyan(pkg.name) + EOL;
-      message += chalk.grey('  * Specified: ') + chalk.reset(pkg.versionSpecified) + EOL;
-      message += chalk.grey('  * Symlinked: ') + chalk.reset(pkg.versionInstalled || '(not available)') + EOL + EOL;
-    });
-    process.stdout.write(message);
+    if (packages.length > 0) {
+      let message = '';
+      message += EOL + chalk.red('Missing ' + type + ' packages: ') + EOL;
+
+      packages.forEach(function(pkg) {
+        message += chalk.reset('Package: ') + chalk.cyan(pkg.name) + EOL;
+        if (pkg.parents) {
+          message += chalk.reset('Required by: ') + chalk.cyan(pkg.parents.join(' / ')) + EOL;
+        }
+        message += chalk.grey('  * Specified: ') + chalk.reset(pkg.versionSpecified) + EOL;
+        message += chalk.grey('  * Installed: ') + chalk.reset(pkg.versionInstalled || '(not installed)') + EOL + EOL;
+      });
+
+      message += chalk.red('Run `'+ installCommand(type) +'` to install missing dependencies.') + EOL;
+      this.messages.push(message);
+    }
   }
-};
 
-Reporter.prototype.report = function() {
-  if (this.messages.length) {
-    const DependencyError = require('./dependency-error');
-    throw new DependencyError(this.messages.join(''));
+  reportUnsatisfiedSymlinkedPackages(type, packages) {
+    this.chalk = this.chalk || require('chalk');
+    this.EOL   = this.EOL || require('os').EOL;
+
+    const chalk = this.chalk;
+    const EOL   = this.EOL;
+
+    if (packages.length > 0) {
+      let message = '';
+      message += EOL + chalk.yellow('Missing symlinked ' + type + ' packages: ') + EOL;
+      packages.forEach(function(pkg) {
+        message += chalk.reset('Package: ') + chalk.cyan(pkg.name) + EOL;
+        message += chalk.grey('  * Specified: ') + chalk.reset(pkg.versionSpecified) + EOL;
+        message += chalk.grey('  * Symlinked: ') + chalk.reset(pkg.versionInstalled || '(not available)') + EOL + EOL;
+      });
+      process.stdout.write(message);
+    }
   }
-};
+
+  report() {
+    if (this.messages.length) {
+      const DependencyError = require('./dependency-error');
+      throw new DependencyError(this.messages.join(''));
+    }
+  }
+}
 
 module.exports = Reporter;

--- a/lib/shrinkwrap-checker.js
+++ b/lib/shrinkwrap-checker.js
@@ -5,73 +5,75 @@ const ShrinkwrapPackage = require('./shrinkwrap-package');
 const path = require('path');
 const resolve = require('resolve');
 
-const ShrinkwrapChecker = function(root, name, versionSpecified, parents, requiredFrom){
-  this.root = root;
-  this.name = name;
-  this.versionSpecified = versionSpecified;
-  this.parents = parents;
-  this.requiredFrom = requiredFrom;
-};
+class ShrinkwrapChecker {
+  constructor(root, name, versionSpecified, parents, requiredFrom) {
+    this.root = root;
+    this.name = name;
+    this.versionSpecified = versionSpecified;
+    this.parents = parents;
+    this.requiredFrom = requiredFrom;
+  }
 
-ShrinkwrapChecker.prototype.check = function() {
-  if (!this.root) {
-    try {
-      this.root = path.dirname(resolve.sync(path.join(this.name, 'package.json'), { basedir: this.requiredFrom }));
-    } catch(err) {
-      // not found
+  check() {
+    if (!this.root) {
+      try {
+        this.root = path.dirname(resolve.sync(path.join(this.name, 'package.json'), { basedir: this.requiredFrom }));
+      } catch(err) {
+        // not found
+      }
     }
+    let packageJSON;
+    if (!this.root) {
+      packageJSON = {};
+    } else {
+      packageJSON = readPackageJSON(this.root) || {};
+    }
+
+    const versionInstalled = packageJSON.version;
+    const resolvedInstalled = packageJSON['_resolved'];
+
+    return new ShrinkwrapPackage(
+      this.name, this.versionSpecified, versionInstalled, resolvedInstalled, this.parents);
   }
-  let packageJSON;
-  if (!this.root) {
-    packageJSON = {};
-  } else {
-    packageJSON = readPackageJSON(this.root) || {};
-  }
 
-  const versionInstalled = packageJSON.version;
-  const resolvedInstalled = packageJSON['_resolved'];
+  static checkDependencies(root, shrinkWrapJSON) {
+    const nodesToCheck = [{
+      root: root,
+      parents: [],
+      childDependencies: shrinkWrapJSON.dependencies,
+      name: shrinkWrapJSON.name,
+      version: shrinkWrapJSON.version
+    }];
 
-  return new ShrinkwrapPackage(
-    this.name, this.versionSpecified, versionInstalled, resolvedInstalled, this.parents);
-};
+    const resolvedDependencies = [];
+    let currentNode, checker, resolved;
+    while ((currentNode = nodesToCheck.pop())) {
+      checker = new ShrinkwrapChecker(
+        currentNode.root, currentNode.name, currentNode.version, currentNode.parents, currentNode.requiredFrom);
 
+      resolved = checker.check();
+      resolvedDependencies.push(resolved);
 
-ShrinkwrapChecker.checkDependencies = function(root, shrinkWrapJSON) {
-  const nodesToCheck = [{
-    root: root,
-    parents: [],
-    childDependencies: shrinkWrapJSON.dependencies,
-    name: shrinkWrapJSON.name,
-    version: shrinkWrapJSON.version
-  }];
+      if (!resolved.needsUpdate && currentNode.childDependencies) {
+        /* jshint loopfunc:true*/
+        const parents = currentNode.parents.concat(currentNode.name);
+        Object.keys(currentNode.childDependencies).forEach(function(childDepName){
+          const childDep = currentNode.childDependencies[childDepName];
 
-  const resolvedDependencies = [];
-  let currentNode, checker, resolved;
-  while ((currentNode = nodesToCheck.pop())) {
-    checker = new ShrinkwrapChecker(
-      currentNode.root, currentNode.name, currentNode.version, currentNode.parents, currentNode.requiredFrom);
-
-    resolved = checker.check();
-    resolvedDependencies.push(resolved);
-
-    if (!resolved.needsUpdate && currentNode.childDependencies) {
-      /* jshint loopfunc:true*/
-      const parents = currentNode.parents.concat(currentNode.name);
-      Object.keys(currentNode.childDependencies).forEach(function(childDepName){
-        const childDep = currentNode.childDependencies[childDepName];
-
-        nodesToCheck.push({
-          requiredFrom: checker.root,
-          parents: parents,
-          name: childDepName,
-          childDependencies: childDep.dependencies,
-          version: childDep.version
+          nodesToCheck.push({
+            requiredFrom: checker.root,
+            parents: parents,
+            name: childDepName,
+            childDependencies: childDep.dependencies,
+            version: childDep.version
+          });
         });
-      });
+      }
     }
-  }
 
-  return resolvedDependencies;
-};
+    return resolvedDependencies;
+  }
+}
+
 
 module.exports = ShrinkwrapChecker;

--- a/lib/shrinkwrap-package.js
+++ b/lib/shrinkwrap-package.js
@@ -2,26 +2,22 @@
 
 const Package = require('./package');
 
-function ShrinkwrapPackage(name, versionSpecified, versionInstalled, resolvedInstalled, parents) {
-  this._super$init.call(this, name, versionSpecified, versionInstalled);
-  this.init(name, versionSpecified, versionInstalled, resolvedInstalled, parents);
+class ShrinkwrapPackage extends Package {
+  constructor(name, versionSpecified, versionInstalled, resolvedInstalled, parents) {
+    super(name, versionSpecified, versionInstalled);
+
+    this.resolvedInstalled = resolvedInstalled;
+    this.parents = parents;
+
+    if (this.needsUpdate && this.resolvedInstalled) {
+      this.needsUpdate = this.versionSpecified !== this.resolvedInstalled;
+    }
+  }
+
+  updateRequired() {
+    return this.versionSpecified !== this.versionInstalled;
+  }
 }
 
-ShrinkwrapPackage.prototype = Object.create(Package.prototype);
-ShrinkwrapPackage.prototype.constructor = ShrinkwrapPackage;
-
-ShrinkwrapPackage.prototype._super$init = Package.prototype.init;
-ShrinkwrapPackage.prototype.init = function(name, versionSpecified, versionInstalled, resolvedInstalled, parents) {
-  this.resolvedInstalled = resolvedInstalled;
-  this.parents = parents;
-
-  if (this.needsUpdate && this.resolvedInstalled) {
-    this.needsUpdate = this.versionSpecified !== this.resolvedInstalled;
-  }
-};
-
-ShrinkwrapPackage.prototype.updateRequired = function() {
-  return this.versionSpecified !== this.versionInstalled;
-};
 
 module.exports = ShrinkwrapPackage;

--- a/lib/version-checker.js
+++ b/lib/version-checker.js
@@ -1,39 +1,38 @@
 'use strict';
 
-function VersionChecker() {
-}
-
-VersionChecker.satisfies = function(versionSpecified, versionInstalled) {
-  if (!versionInstalled) {
-    return false;
-  }
-
-  let version   = versionSpecified;
-  const isGitRepo = require('is-git-url');
-  const semver    = require('semver');
-  const isTarGz   = require('./utils/is-tar-gz');
-  const unknownVersion = require('./utils/unknown-version');
-
-  if (version === '*') {
-    return true;
-  } else if (isGitRepo(version)) {
-    const parts = version.split('#');
-    if (parts.length === 2) {
-      version = semver.valid(parts[1]);
-      if (!version) {
-        return true;
-      }
+class VersionChecker {
+  static satisfies(versionSpecified, versionInstalled) {
+    if (!versionInstalled) {
+      return false;
     }
-  } else if (isTarGz(version) && versionInstalled !== unknownVersion) {
-    const resolve = require('path').resolve;
-    return resolve(version) === resolve(versionInstalled);
-  }
 
-  if (!semver.validRange(version)) {
-    return true;
-  }
+    let version = versionSpecified;
+    const isGitRepo = require('is-git-url');
+    const semver = require('semver');
+    const isTarGz = require('./utils/is-tar-gz');
+    const unknownVersion = require('./utils/unknown-version');
 
-  return semver.satisfies(versionInstalled, version);
-};
+    if (version === '*') {
+      return true;
+    } else if (isGitRepo(version)) {
+       const parts = version.split('#');
+       if (parts.length === 2) {
+         version = semver.valid(parts[1]);
+         if (!version) {
+           return true;
+         }
+       }
+    } else if (isTarGz(version) && versionInstalled !== unknownVersion) {
+       const resolve = require('path').resolve;
+       return resolve(version) === resolve(versionInstalled);
+    }
+
+    if (!semver.validRange(version)) {
+      return true;
+    }
+
+    return semver.satisfies(versionInstalled, version);
+  }
+}
 
 module.exports = VersionChecker;


### PR DESCRIPTION
similar to #86 but rebased on top of https://github.com/quaertym/ember-cli-dependency-checker/pull/91 which should resolve the Node 4 compat issues

Closes #86

/cc @quaertym @rwjblue 