### PR TITLE
Fixing issue with npm ci when dependency is defined as tar.gz url

### DIFF
--- a/lib/dependency-checker.js
+++ b/lib/dependency-checker.js
@@ -119,6 +119,10 @@ class EmberCLIDependencyChecker {
         version = pkgContent.version || null;
         if (isTarGz(versionSpecified)) {
           version = pkgContent._from || unknownVersion;
+          if (version.includes('@')) {
+            // use the bit after the '@'
+            version = version.split('@')[1]
+          }
         }
       } catch(e) {
         // JSON parse error

--- a/tests/fixtures/project-npm-tar-gz-at-check/node_modules/example-tar-gz/package.json
+++ b/tests/fixtures/project-npm-tar-gz-at-check/node_modules/example-tar-gz/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "example-tar-gz",
+  "version": "2.0.0",
+  "_from": "example-tar-gz@http://ember-cli.com/example-2.0.0.tar.gz"
+}

--- a/tests/fixtures/project-yarn-tar-gz-at-check/node_modules/example-tar-gz/package.json
+++ b/tests/fixtures/project-yarn-tar-gz-at-check/node_modules/example-tar-gz/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "example-tar-gz",
+  "version": "2.0.0",
+  "_from": "example-tar-gz@http://ember-cli.com/example-2.0.0.tar.gz"
+}

--- a/tests/unit/dependency-checker-package-manager-test.js
+++ b/tests/unit/dependency-checker-package-manager-test.js
@@ -112,6 +112,11 @@ describe('EmberCLIDependencyChecker', function() {
         const project = createProject({ 'example-tar-gz': 'http://ember-cli.com/example-2.0.0.tar.gz' }, { root: 'tests/fixtures/project-'+ packageManagerName + '-tar-gz-check' });
         assertNoPackageManagerError(project);
       });
+
+      it('when the version specified is a url to a tar.gz and a _from is provided in the package.json with the package-name@ prefix and urls match', function() {
+        const project = createProject({ 'example-tar-gz': 'http://ember-cli.com/example-2.0.0.tar.gz' }, { root: 'tests/fixtures/project-'+ packageManagerName + '-tar-gz-at-check' });
+        assertNoPackageManagerError(project);
+      });
     });
 
     describe('sibling node_modules/ directory', function() {


### PR DESCRIPTION
This is an issue that a friend of mine noticed when trying out the octane preview on CI, essentially when you define a dependency as a tar.gz url you can sometimes get situations where the `_from` url is prefixed with the name of the page and an `@` symbol.

### Steps to reproduce

- `ember new ember-quickstart -b @ember/octane-app-blueprint`
- cd ember-quickstart && npm test
  - no issues
- npm i && npm test
  - (inside the ember-quickstart); no issues
- npm ci && npm test
  - ERROR: `Missing npm packages:`

###  Full error output

```bash
Missing npm packages:
Package: ember-source
  * Specified: https://s3.amazonaws.com/builds.emberjs.com/canary/shas/ed897e5a76c5c11010ce810e140e16e3e42417de.tgz
  * Installed: ember-source@https://s3.amazonaws.com/builds.emberjs.com/canary/shas/ed897e5a76c5c11010ce810e140e16e3e42417de.tgz
```

I don't 100% know the semantics of what this is doing but the change I'm submitting seems to fix it 🤷‍♂️ 