### PR TITLE
Don't verify bower packages those installed via npm|yarn

### DIFF
--- a/lib/dependency-checker.js
+++ b/lib/dependency-checker.js
@@ -133,8 +133,19 @@ class EmberCLIDependencyChecker {
     }
   }
 
+  normalizedBowerDependencies() {
+    const npmDependencies = this.project.dependencies();
+    const bowerDependencies = this.project.bowerDependencies();
+    Object.keys(bowerDependencies).forEach((pkg) => {
+      if(npmDependencies.hasOwnProperty(`@bower_components/${pkg}`)) {
+        delete bowerDependencies[pkg];
+      }
+    });
+    return bowerDependencies;
+  }
+
   readBowerDependencies() {
-    return this.readDependencies(this.project.bowerDependencies(), 'bower');
+    return this.readDependencies(this.normalizedBowerDependencies(), 'bower');
   }
 
   readNPMDependencies() {

--- a/tests/fixtures/project-bower-away/bower.json
+++ b/tests/fixtures/project-bower-away/bower.json
@@ -1,0 +1,6 @@
+{
+  "name": "project-bower-away",
+  "dependencies": {
+    "ember": "1.0.0"
+  }
+}

--- a/tests/fixtures/project-bower-away/node_modules/@bower_components/ember/package.json
+++ b/tests/fixtures/project-bower-away/node_modules/@bower_components/ember/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "ember",
+  "version": "1.0.0"
+}

--- a/tests/unit/dependency-checker-bower-test.js
+++ b/tests/unit/dependency-checker-bower-test.js
@@ -11,10 +11,11 @@ describe('EmberCLIDependencyChecker', function() {
     DependencyChecker.setAlreadyChecked(false);
   });
 
-  function createProject(bowerDependencies) {
+  function createProject(bowerDependencies, npmDependencies = {}) {
     return projectBuilder.build({
       root: 'tests/fixtures/project-bower-check',
-      bowerDependencies: projectBuilder.buildBowerDependencies(bowerDependencies)
+      bowerDependencies: projectBuilder.buildBowerDependencies(bowerDependencies),
+      dependencies: projectBuilder.buildDependencies(npmDependencies),
     });
   }
 
@@ -96,6 +97,11 @@ describe('EmberCLIDependencyChecker', function() {
 
     it('does NOT error with a * dependency', function() {
       const project = createProject({ 'ember': '*' });
+      assertNoBowerError(project);
+    });
+
+    it('when the package is installed via yarn or npm', function() {
+      const project = createProject({ 'ember': '1.0.0' }, { '@bower_components/ember': '1.0.0' });
       assertNoBowerError(project);
     });
   });

--- a/tests/unit/dependency-checker-package-manager-test.js
+++ b/tests/unit/dependency-checker-package-manager-test.js
@@ -65,6 +65,11 @@ describe('EmberCLIDependencyChecker', function() {
         const project = createProject({ 'example-2-tar-gz': 'http://ember-cli.com/example-2-2.0.0.tar.gz' }, { root: 'tests/fixtures/project-'+ packageManagerName + '-tar-gz-check' });
         assertPackageManagerError(project);
       });
+
+      it('when the specified bower package is not installed via npm', function() {
+        const project = createProject({ '@bower_components/foo': '0.1.1' });
+        assertPackageManagerError(project);
+      });
     });
 
     describe('does not report satisfied ' + packageManagerName + ' dependencies', function() {
@@ -115,6 +120,11 @@ describe('EmberCLIDependencyChecker', function() {
 
       it('when the version specified is a url to a tar.gz and a _from is provided in the package.json with the package-name@ prefix and urls match', function() {
         const project = createProject({ 'example-tar-gz': 'http://ember-cli.com/example-2.0.0.tar.gz' }, { root: 'tests/fixtures/project-'+ packageManagerName + '-tar-gz-at-check' });
+        assertNoPackageManagerError(project);
+      });
+
+      it('when the specified bower package is installed via npm', function() {
+        const project = createProject({ '@bower_components/ember': '1.0.0' }, { root: 'tests/fixtures/project-bower-away' });
         assertNoPackageManagerError(project);
       });
     });


### PR DESCRIPTION
Fixes #79 

I simply eliminated `bower` packages which exist in `package.json`.