### PR TITLE
Add ember-cli as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
     "mocha-eslint": "^4.1.0",
     "qunit-dom": "^0.7.0"
   },
+  "peerDependencies": {
+    "ember-cli": "~3.2.0",
+  },
   "engines": {
     "node": ">= 6"
   },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "qunit-dom": "^0.7.0"
   },
   "peerDependencies": {
-    "ember-cli": "~3.2.0",
+    "ember-cli": "~3.2.0"
   },
   "engines": {
     "node": ">= 6"


### PR DESCRIPTION
Adding `ember-cli` as a peer dependency will add a helpful warning if you have the incompatible versions of `ember-cli` and `ember-cli-dependency-checker`.

```
npm WARN ember-cli-dependency-checker@3.2.0 requires a peer of ember-cli@~3.2.0 but none is installed. You must install peer dependencies yourself.
```