### PR TITLE
Allow ember-cli@4 in `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "sinon": "^13.0.0"
   },
   "peerDependencies": {
-    "ember-cli": "~3.2.0"
+    "ember-cli": "~3.2.0 || ^4.0.0"
   },
   "engines": {
     "node": ">= 6"


### PR DESCRIPTION
This seem overdue since Ember CLI v4.0.0 release